### PR TITLE
fail-fast in `qcommit`

### DIFF
--- a/qcommit.sh
+++ b/qcommit.sh
@@ -1,4 +1,5 @@
-#! /bin/bash/
+#! /bin/bash
+set -e
 
 git pull
 git add .


### PR DESCRIPTION
This ensures that if any cmd is cancelled (or, more likely, throws an error) then the shell won't execute further cmds.

However, I recommend using `&&` chaining instead, as it achieves something similar, without using fail-fast as default.

If you want to keep fail-fast as default, then `... || true` can be used to override the exit-code of any cmd by setting it to `0` (`SUCCESS`)